### PR TITLE
InputDialog增加输入类型限制

### DIFF
--- a/app/src/main/java/com/hjq/demo/ui/activity/DialogActivity.java
+++ b/app/src/main/java/com/hjq/demo/ui/activity/DialogActivity.java
@@ -1,6 +1,7 @@
 package com.hjq.demo.ui.activity;
 
 import android.content.Intent;
+import android.text.InputType;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Button;
@@ -119,6 +120,10 @@ public final class DialogActivity extends AppActivity {
                     .setCancel(getString(R.string.common_cancel))
                     // 设置点击按钮后不关闭对话框
                     //.setAutoDismiss(false)
+                    // 设置输入类型
+                    .setInputType(InputType.TYPE_CLASS_NUMBER)
+                    // 设置输入限制
+                    .setDigits("012345")
                     .setListener(new InputDialog.OnListener() {
 
                         @Override

--- a/app/src/main/java/com/hjq/demo/ui/dialog/InputDialog.java
+++ b/app/src/main/java/com/hjq/demo/ui/dialog/InputDialog.java
@@ -1,6 +1,7 @@
 package com.hjq.demo.ui.dialog;
 
 import android.content.Context;
+import android.text.method.DigitsKeyListener;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -44,6 +45,16 @@ public final class InputDialog {
         }
         public Builder setHint(CharSequence text) {
             mInputView.setHint(text);
+            return this;
+        }
+
+        public Builder setInputType(int inputType) {
+            mInputView.setInputType(inputType);
+            return this;
+        }
+
+        public Builder setDigits(String digits) {
+            mInputView.setKeyListener(DigitsKeyListener.getInstance(digits));
             return this;
         }
 


### PR DESCRIPTION
有时候项目中的弹出框对输入字符有要求，平时我在写input的时候也会弹出对应的键盘来输入字符，这样少一步用户切换输入法的动作，体验更好一些，自己拙见还请作者指点。